### PR TITLE
Setup inviting users to app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
 end
 
 gem 'devise'
+gem 'devise_invitable'
 
 gem 'figaro'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    devise_invitable (1.5.2)
+      actionmailer (>= 3.2.6, < 5)
+      devise (>= 3.2.0)
     erubis (2.7.0)
     execjs (2.5.2)
     faker (1.4.3)
@@ -199,6 +202,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise
+  devise_invitable
   faker
   figaro
   haml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up) << :name
+    devise_parameter_sanitizer.for(:accept_invitation) << :name
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,18 @@
+class InvitationsController < Devise::InvitationsController
+  private
+  def invite_resource
+    resource_class.invite!(invite_params, current_inviter) do |u|
+      @organization = current_inviter.organizations.first
+      @membership = Membership.new(organization: @organization, user: u, confirmed: false)
+      @membership.save
+    end
+  end
+
+  def accept_resource
+    resource = resource_class.accept_invitation!(update_resource_params)
+    @membership = resource.memberships.first
+    @membership.update_attribute(:confirmed, true)
+    resource
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
 
+  before_action :authenticate_user!
+
   def show
     @membership = current_user.memberships.first
     if @membership && @membership.confirmed
@@ -9,4 +11,18 @@ class UsersController < ApplicationController
     end
   end
 
+  def update
+    if current_user.update_attributes(user_params)
+      flash[:notice] = "User information updated"
+    else
+      flash[:error] = "Invalid user information"
+    end
+    redirect_to edit_user_registration_path
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ActiveRecord::Base
   has_many :organizations, through: :memberships
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   scope :are_confirmed_members, -> { joins(:memberships).where("'memberships'.'confirmed' = ?", true)}

--- a/app/views/devise/invitations/edit.html.haml
+++ b/app/views/devise/invitations/edit.html.haml
@@ -1,0 +1,17 @@
+.content-header= t 'devise.invitations.edit.header'
+= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f|
+  = devise_error_messages!
+  = f.hidden_field :invitation_token
+  .form-section
+    = f.label :name
+    = f.text_field :name, autofocus: true, class: 'enter-text', autocomplete: "off"
+  .form-section
+    = f.label :password
+    %br/
+    = f.password_field :password, class: 'enter-text'
+  .form-section
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, class: 'enter-text', autocomplete: "off"
+  .form-section
+    = f.submit t("devise.invitations.edit.submit_button"), class: 'submit-form'

--- a/app/views/devise/invitations/new.html.haml
+++ b/app/views/devise/invitations/new.html.haml
@@ -1,0 +1,10 @@
+.content-header= t "devise.invitations.new.header"
+= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f|
+  = devise_error_messages!
+  - resource.class.invite_key_fields.each do |field|
+    .form-section
+      = f.label field
+      %br/
+      = f.text_field field, class: 'enter-text'
+  .form-seciton
+    = f.submit t("devise.invitations.new.submit_button"), class: 'submit-form'

--- a/app/views/devise/mailer/invitation_instructions.html.haml
+++ b/app/views/devise/mailer/invitation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p= t("devise.mailer.invitation_instructions.hello", email: @resource.email)
+%p= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url)
+%p= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token)
+%p= t("devise.mailer.invitation_instructions.ignore").html_safe

--- a/app/views/organizations/edit.html.haml
+++ b/app/views/organizations/edit.html.haml
@@ -18,7 +18,7 @@
   - if @found_users
     .content-subheader= "Search Results for \'#{@query}\'"
     %ul
-    -@found_users.each do |found_user|
+    - @found_users.each do |found_user|
       %li
         = form_for [@organization, @membership] do |f|
           = "#{found_user.name}, #{found_user.email}"
@@ -26,6 +26,9 @@
           = f.hidden_field :confirmed, value: false
           = f.submit "Invite", class: 'invite-user'
       %br
+    - if @found_users.count == 0
+      %p Didn't find who you're looking for? Invite them to join Cogently:
+      = link_to "Invite", new_user_invitation_path, class: 'invite-user'
   = form_tag edit_organization_path(@organization), method: "get" do
     .form-section
       = text_field_tag :search, params[:search], class: 'enter-text', placeholder: 'Search users by email'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -99,6 +99,54 @@ Devise.setup do |config|
   # Setup a pepper to generate the encrypted password.
   # config.pepper = '344acf5c821ea73e7de6d4d8f0c34d81fc9703b5e420bbbf02b4a11485cd8afe18b7b827a842c84f298a2c6b1960513e0b963e284a494965346539df67d640b8'
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid, after
+  # this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/}
+  # config.invite_key = {:email => /\A[^@]+@[^@]+\z/, :username => nil}
+
+  # Flag that force a record to be valid before being actually invited
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: false
+  # config.allow_insecure_sign_in_after_accept = true
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,24 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        ignore: "If you don't want to accept the invitation, please ignore this email.<br />Your account won't be created until you access the link above and set your password."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, :controllers => {:invitations => "invitations"}
   resources :users, only: [:update, :show]
   resources :organizations, only: [:show, :new, :create, :edit, :update, :destroy] do
     resources :memberships, only: [:create, :destroy, :update]

--- a/db/migrate/20150817172938_devise_invitable_add_to_users.rb
+++ b/db/migrate/20150817172938_devise_invitable_add_to_users.rb
@@ -1,0 +1,23 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration
+  def up
+    change_table :users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitations_count
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150811022022) do
+ActiveRecord::Schema.define(version: 20150817172938) do
 
   create_table "memberships", force: :cascade do |t|
     t.integer  "user_id"
@@ -51,9 +51,20 @@ ActiveRecord::Schema.define(version: 20150811022022) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer  "invitation_limit"
+    t.integer  "invited_by_id"
+    t.string   "invited_by_type"
+    t.integer  "invitations_count",      default: 0
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+  add_index "users", ["invitations_count"], name: "index_users_on_invitations_count"
+  add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id"
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end


### PR DESCRIPTION
Closes #6 - When a searched-for user's email is not found, the searching user is prompted to invite the user to join app.  The invitation form also creates an unconfirmed membership record linking the newly invited user and the inviter's organization.
