### PR TITLE
Members can be invited to join another organization.

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -110,6 +110,10 @@ body {
   @extend .btn-success;
 }
 
+.deny-invitation {
+  @extend .btn;
+  @extend .btn-danger;
+}
 .edit-record {
   @extend .btn;
   @extend .btn-default;
@@ -124,4 +128,13 @@ body {
   @extend .btn;
   @extend .btn-xs;
   @extend .btn-success;
+}
+
+/******************************
+  Notice Elements 
+******************************/
+
+.invitation-notice {
+  padding: 2rem;
+  border: 1px lightgreen solid;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,10 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def after_sign_in_path_for(resource_or_scope)
-    if current_user.is_confirmed_member?
-      organization_path(current_user.organization)
-    else
+    if current_user.has_pending_invitation? || !current_user.is_confirmed_member?
       user_path(current_user)
+    else
+      organization_path(current_user.organization)
     end
   end
 

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -16,7 +16,9 @@ class MembershipsController < ApplicationController
 
   def update
     @membership = Membership.find(params[:id])
+    @user = User.find(membership_params[:user_id])
     if @membership.update_attributes(membership_params)
+      @user.update_attribute(:invited_organization_id, nil)
       flash[:notice] = "Membership updated."
     else
       flash[:error] = "There was an error updating membership."
@@ -27,7 +29,7 @@ class MembershipsController < ApplicationController
   private
 
   def membership_params
-    params.require(:membership).permit(:user_id)
+    params.require(:membership).permit(:user_id, :organization_id)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,13 +5,14 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     authorize @user
-    if @user.invited_organization_id
+    if @user.has_pending_invitation?
       @invited_organization = Organization.find(@user.invited_organization_id)
     end
-    @membership = @user.membership
-    if @user.has_pending_invitation?
+    if @user.membership.nil?
+      @membership = Membership.new
       @organization = nil
     else
+      @membership = @user.membership
       @organization = @user.organization
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,6 +39,17 @@ class UsersController < ApplicationController
     redirect_to request.referer || edit_user_registration_path
   end
 
+  def deny
+    @user = User.find(params[:id])
+    authorize @user
+    if @user.update_attribute(:invited_organization_id, nil)
+      flash[:notice] = 'Invitiation turned down.'
+    else
+      flash[:error] = 'An error occurred, please try again.'
+    end
+    redirect_to request.referer || show_user_registration_path
+  end
+
   private
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   def has_pending_invitation?
-    if self.invited_organization_id && self.membership.nil?
-      true
-    else
-      false
-    end
+    return !self.invited_organization_id.nil?
   end
 
   def is_confirmed_member?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -16,4 +16,8 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  def deny?
+    show?
+  end
+
 end

--- a/app/views/organizations/_notice.html.haml
+++ b/app/views/organizations/_notice.html.haml
@@ -1,6 +1,7 @@
 .content-header Notice
 .content-subheader= "You have been invited to join #{invited_organization.name}."
 = form_for [invited_organization, membership] do |f|
+  = f.hidden_field :organization_id, value: invited_organization.id
   = f.hidden_field :user_id, value: current_user.id
   = f.submit "Confirm the Invitation", class: 'submit-form'
 %br

--- a/app/views/organizations/_notice.html.haml
+++ b/app/views/organizations/_notice.html.haml
@@ -1,7 +1,11 @@
-.content-header Notice
-.content-subheader= "You have been invited to join #{invited_organization.name}."
-= form_for [invited_organization, membership] do |f|
-  = f.hidden_field :organization_id, value: invited_organization.id
-  = f.hidden_field :user_id, value: current_user.id
-  = f.submit "Confirm the Invitation", class: 'submit-form'
-%br
+.invitation-notice
+  .content-header Notice
+  .content-subheader= "You have been invited to join #{invited_organization.name}."
+  = form_for [invited_organization, membership] do |f|
+    = f.hidden_field :organization_id, value: invited_organization.id
+    = f.hidden_field :user_id, value: current_user.id
+    = f.submit "Confirm the Invitation", class: 'submit-form'
+  %br
+  = form_for current_user, url: deny_invitation_path, method: :patch do |f|
+    = f.submit "Turn Down Invitation", class: 'deny-invitation'
+  %br

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,6 @@
 .main-content
   - if current_user.has_pending_invitation?
-    = render partial: 'organizations/notice', locals: {membership: Membership.new, invited_organization: @invited_organization }
+    = render partial: 'organizations/notice', locals: {membership: @membership, invited_organization: @invited_organization }
   .content-header= "#{current_user.name}'s Profile"
   - if @organization
     .content-subheader= "Member of #{@organization.name}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, :controllers => {:invitations => "invitations"}
   resources :users, only: [:update, :show]
   patch 'users/:id/invite' => 'users#invite', as: 'invite_user'
+  patch 'users/:id/deny' => 'users#deny', as: 'deny_invitation'
   resources :organizations, only: [:show, :new, :create, :edit, :update, :destroy] do
     resources :memberships, only: [:create, :destroy, :update]
   end


### PR DESCRIPTION
Closes #26 
Updated invitation process to allow a member of an organization to be invited to a different organization.  This updates existing membership record instead of generating new record.  I also streamlined the process of determining a user's invitation and membership status.

To Test:

Run a db:reset
login as first@example.com, password hello world
click "Edit Organization" button
Search for "member" in the sidebar.
Invite a member user to Organization 1 - the member users are seeded as members of organization 1 or 2.
Logout
Sign in as the invited member and click the "confirm invitation" button.
User should now be a member of Organization 1 and should not have access to Organization 2
